### PR TITLE
Fix scrollable side menu menu-items.component.js

### DIFF
--- a/frontend/navbar/menu-items.component.js
+++ b/frontend/navbar/menu-items.component.js
@@ -126,6 +126,7 @@ const css = `
     z-index: 10000;
     left: 0;
     transition: left 0.3s;
+    overflow-y: scroll;
   }
 
   & .side-menu.off-screen {


### PR DESCRIPTION
Side menu was not scrollable on short screens. Mostly a mobile issue. Now it's scrollable on screen of any height.